### PR TITLE
Add metadata handling microservice

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "disaster-management-alerting-service"]
 	path = disaster-management-alerting-service
 	url = https://github.com/dinithrk/disaster-management-alerting-service.git
+[submodule "metadata-handling-service"]
+	path = metadata-handling-service
+	url = https://github.com/Gayu2003-25/disaster_management_metadata_handling_services.git


### PR DESCRIPTION
- Added metadata handling microservice as a Git submodule
- Repository: Gayu2003-25/disaster_management_metadata_handling_services
- Follows existing microservice structure

Next steps:
- Integrate with docker-compose
- Configure API access if needed